### PR TITLE
don't send SIGTERM to child processes when stopping supervisord

### DIFF
--- a/files/supervisord.service
+++ b/files/supervisord.service
@@ -9,6 +9,7 @@ ExecStart=/usr/local/bin/supervisord -c /etc/supervisord.conf
 ExecReload=/usr/local/bin/supervisorctl reload
 ExecStop=/usr/local/bin/supervisorctl shutdown
 User=root
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When systemd stop supervisor, by default it also send TERM to all child
processes. another sigterm is also sent by supervisor to consul agent.
when consul agent received two term signal without doing anything else,
it will exit immediately without proper leave.
https://github.com/hashicorp/consul/blob/c9217c958e35254d8044e2801f61c8370d676f28/command/agent/agent.go#L341

While KillMode is set to process (from default control-group), systemd
only send SIGTERM to the parent process and wait for all processes to
exit.